### PR TITLE
query-refinement-bug fix

### DIFF
--- a/src/HooglePlus/CodeFormer.hs
+++ b/src/HooglePlus/CodeFormer.hs
@@ -81,7 +81,6 @@ applyFunction func = do
         oldSt <- get
         let sigsAvail = take (fromJust (elemIndex func (allSignatures oldSt))) (allSignatures oldSt)
         bodies <- generateProgram sigsAvail (funParams curr) vars (head (funReturn curr)) False -- Set.toList $ HashMap.lookupDefault Set.empty (head (funReturn curr)) tterms
-        liftIO $ print bodies
         put oldSt
         case Set.toList bodies of
             [] -> return []

--- a/src/PetriNet/PNSolver.hs
+++ b/src/PetriNet/PNSolver.hs
@@ -114,7 +114,7 @@ instantiate env sigs = do
                      AbstractRefinement -> leafTypes (st ^. abstractionTree)
                      NoRefine -> filter notEx (leafTypes (st ^. abstractionTree))
                      Combination -> filter notEx (leafTypes (st ^. abstractionTree))
-                     QueryRefinement -> filter notEx (leafTypes (st ^. abstractionTree))
+                     QueryRefinement -> leafTypes (st ^. abstractionTree)
         writeLog 3 $ text "Current abstract types:" <+> pretty typs
         sigs' <- foldM (\acc -> (<$>) ((++) acc) . uncurry (instantiateWith env typs)) [] sigs
         return $ nubOrdOn (uncurry removeSuffix) (sigsAcc ++ sigs')


### PR DESCRIPTION
Query refinement should still generate the exclusion types when starting out. Combination doesn't need them because it starts out with every type in our component set already expressed. However QR does need the exclusion for those missing types.

Also removed an extra print statement.